### PR TITLE
fix(e2e): harness robustness (watch-ignore, WASM streaming, server cleanup)

### DIFF
--- a/frontend/Trunk.toml
+++ b/frontend/Trunk.toml
@@ -29,8 +29,20 @@ inject_scripts = true
 [watch]
 # Paths to watch. The `build.target`'s parent folder is watched by default.
 watch = []
-# Paths to ignore.
-ignore = ["node_modules", "style/uno.css"]
+# Paths to ignore. Besides build inputs, this excludes the Playwright output
+# directories: during `just e2e` the dev server watches `frontend/`, and
+# Playwright continuously writes traces, screenshots, and videos into
+# `test-results/` (and the HTML report into `playwright-report/`). Without these
+# ignores the watcher triggers a storm of rebuilds mid-test, starving the
+# browser's WASM compile/instantiate and intermittently leaving pages blank past
+# the test timeout. Trunk canonicalizes these paths at startup, so the `e2e`
+# recipe creates them first.
+ignore = [
+	"node_modules",
+	"style/uno.css",
+	"test-results",
+	"playwright-report",
+]
 
 [serve]
 # The address to serve on.

--- a/justfile
+++ b/justfile
@@ -234,11 +234,16 @@ e2e: frontend-config frontend-e2e-typecheck
 			trap - EXIT INT TERM
 			memory_map_stop_pid "${frontend_pid:-}"
 			memory_map_stop_pid "${backend_pid:-}"
+			# The servers run behind a `direnv exec`/bash wrapper, so the tracked
+			# pid is the wrapper and the real server can survive on its port. Free
+			# the ports directly so local re-runs are not blocked by an orphan.
+			memory_map_free_port "${E2E_FRONTEND_PORT}"
+			memory_map_free_port "${E2E_BACKEND_PORT}"
 			exit "$status"
 		}
 		trap cleanup_app_servers EXIT INT TERM
 
-		{{ direnv_prefix }} bash -c 'cd backend && exec cargo run --bin backend' > "$E2E_LOG_DIR/backend.log" 2>&1 &
+		{{ direnv_prefix }} bash -c 'cd backend && exec ../target/debug/backend' > "$E2E_LOG_DIR/backend.log" 2>&1 &
 		backend_pid=$!
 		if ! memory_map_wait_for_http "$E2E_BACKEND_URL/" 120 "GraphiQL"; then
 			echo "ERROR: backend did not become ready; see $E2E_LOG_DIR/backend.log." >&2
@@ -246,7 +251,7 @@ e2e: frontend-config frontend-e2e-typecheck
 			return 1
 		fi
 
-		{{ direnv_prefix }} bash -c 'cd frontend && exec env -u NO_COLOR trunk serve --address "$E2E_FRONTEND_HOST" --port "$E2E_FRONTEND_PORT" --no-autoreload --skip-version-check --offline' > "$E2E_LOG_DIR/frontend.log" 2>&1 &
+		{{ direnv_prefix }} bash -c 'cd frontend && exec env -u NO_COLOR trunk serve --address "$E2E_FRONTEND_HOST" --port "$E2E_FRONTEND_PORT" --no-autoreload --skip-version-check --offline --no-sri' > "$E2E_LOG_DIR/frontend.log" 2>&1 &
 		frontend_pid=$!
 		if ! memory_map_wait_for_http "$E2E_FRONTEND_URL/" 120; then
 			echo "ERROR: frontend did not become ready; see $E2E_LOG_DIR/frontend.log." >&2

--- a/justfile
+++ b/justfile
@@ -219,6 +219,10 @@ e2e: frontend-config frontend-e2e-typecheck
 	source scripts/e2e-env.sh
 	source scripts/service-graph.sh
 	mkdir -p "$E2E_LOG_DIR"
+	# Pre-create Playwright's output dirs so the trunk dev server can canonicalize
+	# them as watch-ignore paths at startup (see frontend/Trunk.toml). Without this
+	# the server fails to start on a fresh checkout.
+	mkdir -p frontend/test-results frontend/playwright-report
 
 	run_e2e() {
 		local backend_pid=""

--- a/scripts/service-graph.sh
+++ b/scripts/service-graph.sh
@@ -65,6 +65,27 @@ memory_map_stop_pid() {
 	fi
 }
 
+# Stop whatever is still listening on a local TCP port. The e2e servers run
+# behind a `direnv exec`/bash wrapper, so the tracked pid is the wrapper and the
+# real server (backend, trunk) can survive on its port after the wrapper is
+# killed, blocking the next local run. This targets only the given port, so it
+# never touches unrelated processes. No-op if `ss` is unavailable (e.g. CI,
+# which has no wrapper and so does not orphan in the first place).
+memory_map_free_port() {
+	local port="${1:-}"
+	local pid
+
+	[[ -n "${port}" ]] || return 0
+	command -v ss >/dev/null 2>&1 || return 0
+
+	# Best-effort cleanup; the pipeline's intermediate exit codes are irrelevant.
+	# shellcheck disable=SC2312
+	for pid in $(ss -ltnp 2>/dev/null | grep ":${port} " |
+		grep -oE 'pid=[0-9]+' | grep -oE '[0-9]+' | sort -u); do
+		kill "${pid}" 2>/dev/null || true
+	done
+}
+
 memory_map_with_process_compose() {
 	local port="$1"
 	local log_path="$2"


### PR DESCRIPTION
Three related e2e-harness robustness fixes. The first resolves the post-merge CI flake in #82; the other two address pre-existing weaknesses found while diagnosing it.

## 1. Stop Trunk watching Playwright output (the CI flake)

The E2E job serves the frontend with `trunk serve`, whose watcher covers `frontend/`. Playwright writes traces/screenshots/videos into `frontend/test-results/` throughout a run, so the watcher fired a storm of rebuilds mid-test (533 watcher events / ~537 build starts in the failing run). On a CPU-contended runner those rebuilds starved Chromium's WASM compile, leaving the first authenticated page blank past the 10s assertion timeout (the failure screenshot is a blank page; the heading renders with no backend dependency). Backend-integration, storage-integration, and the other 3 e2e tests passed, it is frontend boot starvation, not the merged backend changes.

Fix: add the Playwright output dirs to Trunk's `[watch] ignore`, and pre-create them in the `e2e` recipe (Trunk canonicalizes ignore paths at startup).

## 2. Stream the WASM bundle (faster, sturdier cold boots)

`trunk serve` does send `application/wasm`, but Trunk's default SRI integrity on the wasm makes the browser fall back from `WebAssembly.instantiateStreaming` to the slower non-streaming `instantiate` of the ~19 MB debug bundle. Pass `trunk serve --no-sri` in the e2e recipe so the browser can stream-compile. Scoped to e2e; production builds keep SRI.

## 3. Do not orphan the app servers on cleanup

The backend was launched via `cargo run` behind a `direnv exec`/bash wrapper, so the tracked pid was the wrapper and the real server survived on its port after cleanup, blocking the next local run. The backend now execs the prebuilt binary directly, and cleanup frees the backend/frontend ports via a new `memory_map_free_port` helper (targeted to those ports; no-op without `ss`). CI is unaffected (no direnv wrapper, fresh runners per job).

## Verification (local)

`just e2e` passes 4/4; watcher `test-results` events `533 -> 0`; the served build has no wasm SRI; both ports are free after the run.

Generated with Claude Code (https://claude.com/claude-code)